### PR TITLE
Added new grant_type metadata item to ROPC TechnicalProfile

### DIFF
--- a/samples/Jumio/Policies/TrustFrameworkBase.xml
+++ b/samples/Jumio/Policies/TrustFrameworkBase.xml
@@ -455,6 +455,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/samples/OnFido-Combined/Policies/TrustFrameworkBase.xml
+++ b/samples/OnFido-Combined/Policies/TrustFrameworkBase.xml
@@ -455,6 +455,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>


### PR DESCRIPTION
This is an update to the docs for B2C custom policies adding a `grant_type` metadata item to ROPC-based technical profiles. Adding this metadata item enables Just-in-time migration via ROPC and REST. See [here](https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack/pull/65) for further details.

This is [already in the official B2C docs](https://github.com/MicrosoftDocs/azure-docs/pull/56409) and should be considered the part of the default base policy.